### PR TITLE
Add whitelisted hard-stop words as an argument

### DIFF
--- a/src/Case.js
+++ b/src/Case.js
@@ -137,13 +137,20 @@
                 return i > 0 && i < s.lastIndexOf(' ') ? _.low.call(small) : small;
             });
         },
-        sentence: function(s, names) {
+        sentence: function(s, names, whitelistedHardStops) {
             s = Case.lower(s).replace(re.sentence, function(m, prelude, letter) {
                 return prelude + _.up.call(letter);
             });
             if (names) {
                 names.forEach(function(name) {
                     s = s.replace(new RegExp('\\b'+Case.lower(name)+'\\b', "g"), _.cap);
+                });
+            }
+            if (whitelistedHardStops) {
+                whitelistedHardStops.forEach(function (word) {
+                    s = s.replace(new RegExp('\\b' + Case.lower(word) + '\\. +(\\w)'), function (fullMatch, firstLetterOfNext) {
+                        return fullMatch.replace(/.$/, _.low.call(firstLetterOfNext));
+                    });
                 });
             }
             return s;

--- a/test/Case_test.js
+++ b/test/Case_test.js
@@ -65,6 +65,11 @@
     strictEqual(output, 'He walked in. "Hi," he said! She replied, "Yes?" "Oh, nevermind."');
   });
 
+  test('whitelisted period words', function() {
+    var output = Case.sentence('the 12 oz. drink was cold', null, ["oz"]);
+    strictEqual(output, 'The 12 oz. drink was cold');
+  });
+
   module('flip');
   flip('low/high', 'TEST THIS', 'test this');
   flip('mixed', "Test This", "tEST tHIS");


### PR DESCRIPTION
There are words like "oz." that should not be used as a segmenter to a new sentence.